### PR TITLE
test(gatsby-source-drupal): diversify fixtures to use mix of string links and object links and ac…

### DIFF
--- a/packages/gatsby-source-drupal/src/__tests__/fixtures/article-2.json
+++ b/packages/gatsby-source-drupal/src/__tests__/fixtures/article-2.json
@@ -1,0 +1,32 @@
+{
+  "data": [
+    {
+      "type": "node--article",
+      "id": "article-3",
+      "attributes": {
+        "id": 23,
+        "uuid": "article-3",
+        "title": "Article #3",
+        "body":
+          "Aliquam non varius libero, sit amet consequat ex. Aenean porta turpis quis vulputate blandit. Suspendisse in porta erat. Sed sit amet scelerisque turpis, at rutrum mauris. Sed tempor eleifend lobortis. Proin maximus, massa sed dignissim sollicitudin, quam risus mattis justo, sit amet aliquam odio ligula quis urna. Interdum et malesuada fames ac ante ipsum primis in faucibus. Ut mollis leo nisi, at interdum urna fermentum ut. Fusce id suscipit neque, eu fermentum lacus. Donec egestas laoreet felis ac luctus. Vestibulum molestie mattis ante, a vulputate nunc ullamcorper at. Ut hendrerit ipsum eget gravida ultricies."
+      },
+      "relationships": {
+        "field_main_image": {
+          "data": {
+            "type": "file--file",
+            "id": "file-1"
+          }
+        },
+        "field_tags": {
+          "data": [
+            {
+              "type": "taxonomy_term--tags",
+              "id": "tag-1"
+            }
+          ]
+        }
+      }
+    }
+  ],
+  "links": {}
+}

--- a/packages/gatsby-source-drupal/src/__tests__/fixtures/article.json
+++ b/packages/gatsby-source-drupal/src/__tests__/fixtures/article.json
@@ -49,34 +49,9 @@
           "data": null
         }
       }
-    },
-    {
-      "type": "node--article",
-      "id": "article-3",
-      "attributes": {
-        "id": 23,
-        "uuid": "article-3",
-        "title": "Article #3",
-        "body":
-          "Aliquam non varius libero, sit amet consequat ex. Aenean porta turpis quis vulputate blandit. Suspendisse in porta erat. Sed sit amet scelerisque turpis, at rutrum mauris. Sed tempor eleifend lobortis. Proin maximus, massa sed dignissim sollicitudin, quam risus mattis justo, sit amet aliquam odio ligula quis urna. Interdum et malesuada fames ac ante ipsum primis in faucibus. Ut mollis leo nisi, at interdum urna fermentum ut. Fusce id suscipit neque, eu fermentum lacus. Donec egestas laoreet felis ac luctus. Vestibulum molestie mattis ante, a vulputate nunc ullamcorper at. Ut hendrerit ipsum eget gravida ultricies."
-      },
-      "relationships": {
-        "field_main_image": {
-          "data": {
-            "type": "file--file",
-            "id": "file-1"
-          }
-        },
-        "field_tags": {
-          "data": [
-            {
-              "type": "taxonomy_term--tags",
-              "id": "tag-1"
-            }
-          ]
-        }
-      }
     }
   ],
-  "links": {}
+  "links": {
+    "next": "http://fixture/jsonapi/node/article-2"
+  }
 }

--- a/packages/gatsby-source-drupal/src/__tests__/fixtures/jsonapi.json
+++ b/packages/gatsby-source-drupal/src/__tests__/fixtures/jsonapi.json
@@ -4,6 +4,8 @@
       "self": "http://fixture/jsonapi",
       "file--file": "http://fixture/jsonapi/file/file",
       "node--article": "http://fixture/jsonapi/node/article",
-      "taxonomy_term--tags": "http://fixture/jsonapi/taxonomy_term/tags"
+      "taxonomy_term--tags": {
+        "href": "http://fixture/jsonapi/taxonomy_term/tags"
+      }
   }
 }

--- a/packages/gatsby-source-drupal/src/__tests__/fixtures/tags-2.json
+++ b/packages/gatsby-source-drupal/src/__tests__/fixtures/tags-2.json
@@ -2,12 +2,12 @@
   "data": [
     {
       "type": "taxonomy_term--tags",
-      "id": "tag-1",
+      "id": "tag-2",
       "attributes": {
-        "id": 11,
-        "uuid": "tag-1",
+        "id": 12,
+        "uuid": "tag-2",
         "langcode": "en",
-        "name": "Tag #1",
+        "name": "Tag #2",
         "description": null,
         "weight": 0,
         "changed": 1523031646,
@@ -20,9 +20,5 @@
       }
     }
   ],
-  "links": {
-    "next": {
-      "href": "http://fixture/jsonapi/taxonomy_term/tags-2"
-    }
-  }
+  "links": {}
 }


### PR DESCRIPTION
this changes our fixture to be some kind of frankenstein monster using mix of "old" style string links and object with "href" and also simulate paged responses (using `links.next`)

Ref #9356